### PR TITLE
Code cleanup (luacheck)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,13 @@
+codes = true
+
+std = "lua53c"
+max_line_length = 150
+
+
+files["test/"] = {
+    ignore = { "211/msg", "411/msg", "421/err", "212/ctx", "212/cctx" }
+}
+
+files["example/"] = {
+    ignore = { "211/msg", "411/msg" }
+}

--- a/example/lace-example.lua
+++ b/example/lace-example.lua
@@ -70,6 +70,9 @@ local lace = require 'lace'
 -- name of the loaded ruleset (used for further errors etc) and the
 -- content of the ruleset as a string.
 --
+
+--luacheck: ignore 212/comp_ctx
+
 local function lace_loader(comp_ctx, name)
    local fname = base_dir .. "/" .. name .. ".rules"
    local fh = io.open(fname, "r")

--- a/lib/lace.lua
+++ b/lib/lace.lua
@@ -37,5 +37,5 @@ return {
    _VERSION = _VERSION,
    VERSION = VERSION,
    _ABI = _ABI,
-   ABI = ABI,
+   ABI = _ABI,
 }

--- a/lib/lace/builtin.lua
+++ b/lib/lace/builtin.lua
@@ -118,7 +118,7 @@ end
 --
 -- Allowing and denying access is, after all, what access control lists are all
 -- about.  This function compiles in an `allow` or `deny` statement including
--- noting what kind of access statement it is and what 
+-- noting what kind of access statement it is and what
 --
 -- @tparam table compcontext The compilation context
 -- @tparam string result The result to be compiled (`allow` or `deny`).
@@ -300,7 +300,7 @@ end
 --
 -- Definitions are a core behaviour of Lace.  This builtin allows the ruleset
 -- to define additional conditions on which `allow`, `deny` and `include` can
--- operate.  
+-- operate.
 --
 -- @tparam table compcontext The compilation context.
 -- @tparam string define The word which triggered this compilation command.
@@ -329,7 +329,7 @@ function builtin.define(compcontext, define, name, controltype, ...)
 
    local controlfn = _controlfn(compcontext, controltype)
    if not controlfn then
-      emsg = "%s's second parameter (%s) must be a control type such as anyof"
+      local emsg = "%s's second parameter (%s) must be a control type such as anyof"
       return err.error(emsg:format(define, controltype), {3})
    end
 
@@ -357,16 +357,19 @@ builtin.def = builtin.define
 --[ Inclusion of rulesets ]-------------------------------------------
 
 local function _do_include(exec_context, rule, ruleset, conds)
-   local pass, msg = run_conditions(exec_context, conds)
-   if pass == nil then
-      -- Propagate errors
-      msg = err.offset(msg, 2)
-      msg = err.augment(msg, rule.source, rule.linenr)
-      return nil, msg
-   elseif pass == false then
-      -- Conditions failed, return true to continue execution
-      return true
+   do
+      local pass, msg = run_conditions(exec_context, conds)
+      if pass == nil then
+         -- Propagate errors
+         msg = err.offset(msg, 2)
+         msg = err.augment(msg, rule.source, rule.linenr)
+         return nil, msg
+      elseif pass == false then
+         -- Conditions failed, return true to continue execution
+         return true
+      end
    end
+
    -- Essentially we run the ruleset and return its values
    local result, msg = engine.internal_run(ruleset, exec_context)
    if result == "" then
@@ -404,7 +407,7 @@ function builtin.include(comp_context, cmd, file, ...)
    local safe_if_not_present = cmd:sub(-1) == "?"
 
    local conds = {...}
-   
+
    if type(file) ~= "string" then
       return err.error("No ruleset named for inclusion", {1})
    end
@@ -436,14 +439,14 @@ function builtin.include(comp_context, cmd, file, ...)
       err.offset(content, 1)
       return real, content
    end
-   
+
    -- Okay, the file is present, let's parse it.
    local ruleset, msg = compiler().internal_compile(comp_context, real, content, true)
    if type(ruleset) ~= "table" then
       -- Propagation of the error means rendering and taking ownership...
       return err.error(err.render(msg) .. "\nwhile including " .. file, {2})
    end
-   
+
    -- Okay, we parsed, so build the runtime
    local rule = {
       fn = _do_include,

--- a/lib/lace/compiler.lua
+++ b/lib/lace/compiler.lua
@@ -19,11 +19,11 @@ local err = require "lace.error"
 
 local unpack = unpack or table.unpack
 
-local function _fake_loader(ctx, name)
+local function _fake_loader(ctx, name) --luacheck: ignore 212/ctx
    return err.error("Ruleset not found: " .. name, {1})
 end
 
-local function _fake_command(ctx)
+local function _fake_command(ctx) --luacheck: ignore 212/ctx
    return err.error("Command is disabled by context")
 end
 
@@ -91,7 +91,7 @@ local function transfer_args(compcontext, content, rules)
          function definerule.fn(exec_context, rule, name, defn)
             local fn = defn.fn
             function defn.fn(...)
-               local res, msg = fn(...)
+               local res, msg = fn(...) --luacheck: ignore 431/msg
                if res == nil then
                   msg = err.offset(msg, -2)
                   return nil, msg
@@ -123,13 +123,13 @@ local function compile_one_line(compcontext, line)
    if type(rules) ~= "table" then
       return rules, args
    end
-   
-   local linerule, err = cmdfn(compcontext, unpack(args))
+
+   local linerule, msg = cmdfn(compcontext, unpack(args))
    if type(linerule) ~= "table" then
-      return linerule, err
+      return linerule, msg
    end
    rules[#rules+1] = linerule
-   return rules, err
+   return rules, msg
 end
 
 --- Internal ruleset compilation.
@@ -172,7 +172,7 @@ local function internal_compile_ruleset(compcontext, sourcename, content, suppre
       content = lexed_content,
       rules = {},
    }
-   
+
    local prev_uncond_result = builtin.get_set_last_unconditional_result()
    local prev_result = builtin.get_set_last_result()
 
@@ -264,8 +264,8 @@ local function compile_ruleset(ctx, src, cnt)
       ctx._lace.linenr = 1
       ctx._lace.magic_define_nr = 1
    end
-   local ok, ret, msg = xpcall(function() 
-				  return internal_compile_ruleset(ctx, src, cnt) 
+   local ok, ret, msg = xpcall(function()
+				  return internal_compile_ruleset(ctx, src, cnt)
 			       end, debug.traceback)
    if not ok then
       return nil, ret

--- a/lib/lace/compiler.lua
+++ b/lib/lace/compiler.lua
@@ -17,7 +17,7 @@ local lex = require "lace.lex"
 local builtin = require "lace.builtin"
 local err = require "lace.error"
 
-local unpack = unpack or table.unpack
+local unpack = unpack or table.unpack --luacheck: ignore 113/unpack
 
 local function _fake_loader(ctx, name) --luacheck: ignore 212/ctx
    return err.error("Ruleset not found: " .. name, {1})

--- a/lib/lace/engine.lua
+++ b/lib/lace/engine.lua
@@ -115,10 +115,11 @@ end
 --                 otherwise it is an additional message to go with the result.
 -- @function run
 local function run_ruleset(ruleset, exec_context)
-   local ok, ret, msg = xpcall(function() 
+   local ok, ret, msg = xpcall(function()
 				  return internal_run_ruleset(ruleset, exec_context)
 			       end, debug.traceback)
    if not ok then
+     --luacheck: ignore 421/msg
       local _, msg = err.error(ret, {1})
       return nil, err.render(err.augment(msg, ruleset.rules[1].source, ruleset.rules[1].linenr))
    end

--- a/lib/lace/engine.lua
+++ b/lib/lace/engine.lua
@@ -15,7 +15,7 @@
 
 local err = require 'lace.error'
 
-local unpack = unpack or table.unpack
+local unpack = unpack or table.unpack --luacheck: ignore 113/unpack
 
 local function _dlace(ctx)
    local ret = ctx._lace or {}

--- a/lib/lace/error.lua
+++ b/lib/lace/error.lua
@@ -50,8 +50,7 @@ local function _offset(err, offs)
    end
    for k, w in ipairs(err.words) do
       if type(w) == "table" then
-         nr = w.nr
-         err.words[k] = {nr = nr + offs, sub=w.sub}
+         err.words[k] = {nr = w.nr + offs, sub=w.sub}
       else
          err.words[k] = w + offs
       end
@@ -103,9 +102,9 @@ local function _render(err)
    local ret = { err.msg }
 
    local wordset = {}
-   local function build_wordset(words, wordset, parent_source, parent_linenr)
-      wordset.source = words.source or source
-      wordset.linenr = words.linenr or linenr
+   local function build_wordset(words, wordset, parent_source, parent_linenr) --luacheck: ignore 431/wordset
+      wordset.source = words.source or parent_source
+      wordset.linenr = words.linenr or parent_linenr
       for _, word in ipairs(words) do
          if type(word) ~= "table" then
             wordset[word] = true
@@ -119,7 +118,7 @@ local function _render(err)
    build_wordset(err.words, wordset)
 
    local linelist = {}
-   local function build_linelist(wordset, parent_source, parent_linenr)
+   local function build_linelist(wordset, parent_source, parent_linenr) --luacheck: ignore 431/wordset
       if parent_source ~= wordset.source or parent_linenr ~= wordset.linenr then
          linelist[#linelist+1] = wordset
       end
@@ -135,7 +134,7 @@ local function _render(err)
    end
    build_linelist(wordset)
 
-   local function mark_my_words(line, wordset)
+   local function mark_my_words(line, wordset) --luacheck: ignore 431/wordset
       local hlstr, cpos = "", 1
       for w, info in ipairs(line) do
          -- Ensure that we're up to the start position of the word
@@ -170,7 +169,7 @@ local function _render(err)
       return hlstr, cpos
    end
 
-   for _, wordset in ipairs(linelist) do
+   for _, wordset in ipairs(linelist) do --luacheck: ignore 421/wordset
       ret[#ret+1] = wordset.source.source .. " :: " .. tostring(wordset.linenr)
       local srcline = wordset.source.lines[wordset.linenr] or {
          original = "???", content = { {spos = 1, epos = 3, str = "???"} }

--- a/lib/lace/lex.lua
+++ b/lib/lace/lex.lua
@@ -30,7 +30,7 @@ local function _lex_one_line(line, terminator)
    while #line > 0 do
       c, line = line:match("^(.)(.*)$")
       cpos = cpos + 1
-      if escaping then 
+      if escaping then
 	 if quoting then
 	    if c == "n" then
 	       acc = acc .. "\n"
@@ -134,7 +134,7 @@ function M.string(ruleset, sourcename)
    local lines = {}
    local ret = { source = sourcename, lines = lines }
    local n = 1
-   local warn
+   local warn, rest_of_line
    if ruleset:match("[^\n]$") then
       ruleset = ruleset .. "\n"
    end

--- a/lib/lace/lex.lua
+++ b/lib/lace/lex.lua
@@ -23,6 +23,7 @@ local function _lex_one_line(line, terminator)
    local r = {}
    local acc = ""
    local c
+   local warnings = {}
    local escaping = false
    local quoting = false
    local force_empty = false
@@ -62,6 +63,12 @@ local function _lex_one_line(line, terminator)
 	 elseif c == '[' and quoting == false then
 	    -- Something worth lexing
 	    local ltab, rest, warns = lex_one_line(line, "]")
+	    if warns then
+	        -- Add to our list of warnings
+	        for _, warning in ipairs(warns) do
+	            warnings[#warnings+1] = warning;
+	        end
+	    end
 	    -- For now, assume the accumulator is good enough
 	    cpos = cpos + #line - #rest
 	    r[#r+1] = { spos = spos, epos = cpos, sub = ltab, acc = acc }
@@ -100,7 +107,6 @@ local function _lex_one_line(line, terminator)
       r[#r+1] = { spos = spos, epos = cpos, str = acc }
    end
 
-   local warnings = {}
    if quoting then
       warnings[#warnings+1] = "Un-terminated quoted string"
    end

--- a/test/test-lace.builtin.lua
+++ b/test/test-lace.builtin.lua
@@ -14,7 +14,7 @@ pcall(require, 'luacov')
 local builtin = require 'lace.builtin'
 local engine = require 'lace.engine'
 
-local unpack = unpack or table.unpack
+local unpack = unpack or table.unpack --luacheck: ignore 113/unpack
 
 local testnames = {}
 
@@ -168,7 +168,7 @@ function suite.compile_builtin_default_twice()
    local compctx = {_lace = {}}
    local cmdtab, msg = builtin.commands.default(compctx, "default", "allow", "")
    assert(type(cmdtab) == "table", "Successful compilation should return a table")
-   local cmdtab, msg = builtin.commands.default(compctx, "default", "allow", "")
+   local cmdtab, msg = builtin.commands.default(compctx, "default", "allow", "") --luacheck: ignore 411/cmdtab
    assert(cmdtab == false, "Internal errors should return false")
    assert(type(msg) == "table", "Internal errors should return tables")
    assert(type(msg.msg) == "string", "Internal errors should have string messages")

--- a/test/test-lace.compiler.lua
+++ b/test/test-lace.compiler.lua
@@ -143,7 +143,7 @@ local comp_context = {
 	 nocompile = function()
 			return err.error("NOCOMPILE", {2})
 		     end,
-	 equal = function(ctx, eq, key, value)
+	 equal = function(ctx, eq, key, value) --luacheck: ignore 212/eq
 		    return {
 		       fn = function(ectx, ekey, evalue)
 			       return ectx[ekey] == evalue

--- a/test/test-lace.engine.lua
+++ b/test/test-lace.engine.lua
@@ -39,7 +39,7 @@ function suite.check_cannot_redefine_something()
    local ctx = {}
    local result, msg = lace.engine.define(ctx, "this", "that")
    assert(result == true, "Couldn't define something")
-   local result, msg = lace.engine.define(ctx, "this", "that")
+   local result, msg = lace.engine.define(ctx, "this", "that") --luacheck: ignore 411/result
    assert(result == false, "Should not have been able to redefine this")
    assert(type(msg) == "table", "Internal errors should be tables")
    assert(type(msg.msg) == "string", "Internal errors should have message strings")
@@ -57,14 +57,14 @@ end
 
 function suite.check_can_test_known_functions()
    local ctx = {}
-   local function run_test(ctx, arg)
+   local function run_test(ctx, arg) --luacheck: ignore 431/ctx
       assert(arg == "FISH", "Argument not passed properly")
       ctx.ran = true
       return "fish", "blah"
    end
    local result, msg = lace.engine.define(ctx, "this", { fn = run_test, args = { "FISH" } })
    assert(result == true, "Could not make definition?")
-   local result, msg = lace.engine.test(ctx, "this")
+   local result, msg = lace.engine.test(ctx, "this") --luacheck: ignore 411/result
    assert(result == "fish", "Expected result was not returned")
    assert(msg == "blah", "Expected message was not returned")
    assert(ctx.ran, "Context was not passed properly")
@@ -125,7 +125,7 @@ local comp_context = {
       commands = {
       },
       controltype = {
-	 equal = function(ctx, eq, key, value)
+	 equal = function(ctx, eq, key, value) --luacheck: ignore 212/eq
 		    return {
 		       fn = function(ectx, ekey, evalue)
 			       return ectx[ekey] == evalue
@@ -133,7 +133,7 @@ local comp_context = {
 		       args = { key, value },
 		    }
 		 end,
-	 error = function(ctx, err)
+	 error = function(ctx, err) --luacheck: ignore 212/err
 		    return {
 		       fn = function(ectx)
 			       if ectx.error then
@@ -190,7 +190,7 @@ function suite.test_complex_ruleset()
    for _, s in ipairs{"one","two","three","four"} do
       local expect = (s == "one" or s == "two") and "allow" or "deny"
       local ectx = {state=s}
-      local result, msg = lace.engine.run(ruleset, ectx)
+      local result, msg = lace.engine.run(ruleset, ectx) --luacheck: ignore 421/msg
       assert(result == expect, "Expected " .. expect)
       assert(msg == s, "Reason expected " .. s)
    end

--- a/test/test-lace.error.lua
+++ b/test/test-lace.error.lua
@@ -39,6 +39,7 @@ function suite.error_formation()
 end
 
 function suite.error_offset()
+   --luacheck: ignore 211/f
    local words = {3,5}
    local f, err = error.error("msg", words)
    local nerr = error.offset(err, 2)
@@ -48,6 +49,7 @@ function suite.error_offset()
 end
 
 function suite.error_augmentation()
+   --luacheck: ignore 211/f
    local f, err = error.error("msg")
    local src = {}
    local aug = error.augment(err, src, 10)
@@ -57,6 +59,7 @@ function suite.error_augmentation()
 end
 
 function suite.error_render()
+   --luacheck: ignore 211/f
    local f, err = error.error("msg", {1, 3})
    local src = { source = "SOURCE", lines = {
 	 {
@@ -83,6 +86,7 @@ function suite.error_render()
 end
 
 function suite.error_render_bad_line()
+   --luacheck: ignore 211/f
    local f, err = error.error("msg", {1, 3})
    local src = { source = "SOURCE", lines = { } }
    error.augment(err, src, 1)


### PR DESCRIPTION
Hey, as promised long ago, here is a PR of changes to get lace luacheck-clean.

As with all linters, there was a bunch of noise (especially in the tests where I simply silenced common patterns with some rules in `.luacheckrc`). However some actual issues were found and fixed, such as leaking globals or discarding lexer warnings without reporting them.

There remains the issue of whitespace throughout (mixed tabs and spaces in places). So... tabs or spaces? :) (disclaimer: I'm a tabs guy, but happy to go with whatever you want).