### PR TITLE
Try newer location for 'unpack' first

### DIFF
--- a/lib/lace/compiler.lua
+++ b/lib/lace/compiler.lua
@@ -17,7 +17,7 @@ local lex = require "lace.lex"
 local builtin = require "lace.builtin"
 local err = require "lace.error"
 
-local unpack = unpack or table.unpack --luacheck: ignore 113/unpack
+local unpack = table.unpack or unpack --luacheck: ignore 113/unpack
 
 local function _fake_loader(ctx, name) --luacheck: ignore 212/ctx
    return err.error("Ruleset not found: " .. name, {1})

--- a/lib/lace/engine.lua
+++ b/lib/lace/engine.lua
@@ -15,7 +15,7 @@
 
 local err = require 'lace.error'
 
-local unpack = unpack or table.unpack --luacheck: ignore 113/unpack
+local unpack = table.unpack or unpack --luacheck: ignore 113/unpack
 
 local function _dlace(ctx)
    local ret = ctx._lace or {}


### PR DESCRIPTION
`table.unpack` is the cannonical location since Lua 5.2 so it makes some
sense to check there first before falling back to the Lua 5.1 global

Noticed because it trips the sandbox when loaded in Prosody